### PR TITLE
Retry downloading nltk data up to 8 times

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -23,7 +23,7 @@ COPY ./requirements /requirements
 RUN pip install -r /requirements/local.txt
 
 # Required by LexMapr package
-RUN python -m nltk.downloader all
+RUN for i in 1 2 3 4 5 6 7 8; do python -m nltk.downloader all && break || sleep 15; done
 
 COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r//' /entrypoint


### PR DESCRIPTION
Fixes #3.

The nltk dataset is large, so downloads may fail during docker image building.

This will retry downloads up to 8 times if downloads fail. Existing datasets will be skipped during retries if they were downloaded successfully on a previous try.